### PR TITLE
Fix/execute estimate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3034,9 +3034,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.1.0.tgz",
-      "integrity": "sha512-TihZitscnaHNcZgXGj9zDLDyCqjziytB4tMCwXq0XimfWkAjBYyk5/pOsDbbwcavhlc79HhpTEpQcrMnPVa1mw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.2.0.tgz",
+      "integrity": "sha512-LD4NnkKpHHSMo5z9MvFsG4g1xxZUDqV3A3Futu3nvyfs4wPwXxqOgMaxOoa2PeyGL2VNeSlbxT54enbQzGcgJQ=="
     },
     "@openzeppelin/test-helpers": {
       "version": "0.5.11",
@@ -3076,9 +3076,9 @@
       }
     },
     "@rsksmart/rif-scheduler-contracts": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-scheduler-contracts/-/rif-scheduler-contracts-1.0.0-beta.1.tgz",
-      "integrity": "sha512-I4YbWGUfqHtq6yHRDnnzlxbasNjcMQq8P3a/aMFjmXeSmZFyBJoofIFwMcuIA2SfbkaMF+TOjzmIBf9te5z/Dw==",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-scheduler-contracts/-/rif-scheduler-contracts-1.0.0-beta.2.tgz",
+      "integrity": "sha512-wz3vPgFoU4ThhXLmg977aS5nv7qiiIKypbYjOd/tiwH442X4II+14ygw44OVmXuvamr5/8FGtIM4PLDtw9DUJw==",
       "requires": {
         "@openzeppelin/contracts": "^4.1.0",
         "@rsksmart/erc677": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/rsksmart/rif-scheduler-services#readme",
   "dependencies": {
     "@openzeppelin/test-helpers": "^0.5.11",
-    "@rsksmart/rif-scheduler-contracts": "^1.0.0-beta.1",
+    "@rsksmart/rif-scheduler-contracts": "^1.0.0-beta.2",
     "@truffle/hdwallet-provider": "^1.4.1",
     "date-fns": "^2.22.1",
     "dotenv": "^10.0.0",

--- a/src/scripts/setupContracts.ts
+++ b/src/scripts/setupContracts.ts
@@ -116,8 +116,8 @@ export const setupContracts = async (
   web3.eth.defaultAccount = accounts.contractAdmin
 
   const plans = [
-    { price: 15, window: 10000, gasLimit: 100000 },
-    { price: 4, window: 300, gasLimit: 10000000 }
+    { price: 15, window: 10000, gasLimit: 10000000 },
+    { price: 15, window: 10000, gasLimit: 10000 } // very low gasLimit
   ]
 
   const tokenTransferGas = await token.methods
@@ -127,13 +127,15 @@ export const setupContracts = async (
     .transfer(accounts.requestor, 100000)
     .send({ from: accounts.contractAdmin, gas: tokenTransferGas })
 
-  const addPlanGas = await rifScheduler.methods
-    .addPlan(plans[0].price, plans[0].window, plans[0].gasLimit, token.options.address)
-    .estimateGas({ from: accounts.serviceProvider })
+  for (const plan of plans) {
+    const addPlanGas = await rifScheduler.methods
+      .addPlan(plan.price, plan.window, plan.gasLimit, token.options.address)
+      .estimateGas({ from: accounts.serviceProvider })
 
-  await rifScheduler.methods
-    .addPlan(plans[0].price, plans[0].window, plans[0].gasLimit, token.options.address)
-    .send({ from: accounts.serviceProvider, gas: addPlanGas })
+    await rifScheduler.methods
+      .addPlan(plan.price, plan.window, plan.gasLimit, token.options.address)
+      .send({ from: accounts.serviceProvider, gas: addPlanGas })
+  }
 
   const getExecutionParameters = async (
     abi: AbiItem[],

--- a/test/Executor.test.ts
+++ b/test/Executor.test.ts
@@ -101,8 +101,9 @@ describe('Executor', function (this: {
 
     await txExecutor.execute(transaction)
 
-    const result = await txExecutor.execute(transaction)
-    expect(result.error!.message).toEqual('State must be Scheduled')
+    const result2 = await txExecutor.execute(transaction)
+
+    expect(result2.error!.message).toEqual('State must be Scheduled')
   })
 
   test('Should execute a some other contract scheduled', async () => {


### PR DESCRIPTION
In the Executor module we need to estimate the gas before sending the transaction, but if the user choose a plan with lower gasLimit that the needed for the execution the estimation will fail before execute the tx, in that case, the SP will never execute the tx and after many retries it will result in an overdue state, but this is not a problem with the SP because the solution should be that the user choose a plan with a bigger gas limit.